### PR TITLE
Add Captain Claw (OpenClaw) port

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Live site: <https://producdevity.github.io/MiyooMini-Ports/>
 | [ONScripter-jh](https://github.com/weimingtom/onscripter-jh-miyoo-mini-plus) | Engine | Source only | Owned data | weimingtom |
 | [Half-Life](https://github.com/IC-0n417/half-life-miyoo-mini-plus/releases) | FPS | Prerelease | Owned data | IC-0n417 |
 | [Quake II](https://github.com/Apaczer/quake2-miyoo/releases) | FPS | Playable | Owned data | Apaczer |
+| [Captain Claw](https://github.com/ArticlessCZ-Coder/captain-claw-miyoo/releases) | Platform | Playable | Owned data | ArticlessCZ-Coder |
 | [SuperTux](https://github.com/andrigamerita/supertux/releases) | Platform | Playable | Free | andrigamerita |
 | [Frozen Bubble](https://github.com/mehdisadeghi/frozen-bubble-onion/releases) | Puzzle | Playable | Free | mehdisadeghi |
 | [Elasto Mania](https://github.com/neri-rnd/elma-miyoo/releases) | Racing | Playable | Owned data | neri-rnd |

--- a/porters.json
+++ b/porters.json
@@ -4,6 +4,9 @@
     "Apaczer": {
       "github": "https://github.com/Apaczer"
     },
+    "ArticlessCZ-Coder": {
+      "github": "https://github.com/ArticlessCZ-Coder"
+    },
     "ElijahTowers": {
       "github": "https://github.com/ElijahTowers"
     },

--- a/ports.json
+++ b/ports.json
@@ -380,6 +380,16 @@
       "image": "https://raw.githubusercontent.com/hotcereal/files/main/TimeQuickFix.png",
       "notes": "Sets system time via NTP/Cloudflare. Mini Plus (WiFi).",
       "porter": ["hotcereal"]
+    },
+    {
+      "name": "Captain Claw",
+      "category": "platform",
+      "status": "playable",
+      "assets": "owned",
+      "upstream": "https://github.com/ArticlessCZ-Coder/captain-claw-miyoo/releases",
+      "image": "https://github.com/user-attachments/assets/4664ef2b-4eea-460b-a707-3428fea89103",
+      "notes": "OpenClaw engine port. Supply your own CLAW.REZ from the original 1997 game. Levels 1-7 (all OpenClaw implements) are playable; no music, as the game's MIDI needs a synth this build deliberately omits. Hold MENU to quit.",
+      "porter": ["ArticlessCZ-Coder"]
     }
   ]
 }


### PR DESCRIPTION
﻿Adds **Captain Claw**, an [OpenClaw](https://github.com/pjasicek/OpenClaw) engine port for the Miyoo Mini and Mini Plus under OnionOS.

- **Repo:** https://github.com/ArticlessCZ-Coder/captain-claw-miyoo
- **Release:** https://github.com/ArticlessCZ-Coder/captain-claw-miyoo/releases (SD card zip, ready to unzip onto the card)
- **Engine sources:** https://github.com/ArticlessCZ-Coder/openclaw-miyoo (GPLv3, as the licence requires)

Players supply their own `CLAW.REZ` from the original 1997 game - no game data is distributed.

Levels 1-7 (everything OpenClaw implements) are playable at a steady frame rate, with working sound, checkpoints and saves. Music is off: the game's music is MIDI and this build deliberately has no synth, since the usual one pulls in the desktop audio stack the device does not have. Both are stated in the notes field.

Tested on a Mini Plus, including a clean install following the published instructions.

Ran `pnpm validate`, `pnpm check` and `pnpm gen:readme`; the README table is regenerated in this commit.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the Captain Claw (OpenClaw) engine port to the Miyoo Mini/Mini Plus catalog so it appears on the site with correct metadata. No schema changes; this only updates JSON data and the README table.

- ports.json: new “Captain Claw” entry (platform, playable, assets “owned”) with upstream release link, image, and notes (requires CLAW.REZ; levels 1–7 playable; no MIDI music; hold MENU to quit).
- porters.json: adds porter “ArticlessCZ-Coder”.
- README.md: regenerates the table to include the new port.

<sup>Written for commit 1c2fcc8934250bad2ae1133fac3456eeccc5ae05. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Producdevity/MiyooMini-Ports/pull/1?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

