### PR TITLE
Update ports.json: Add Petals Around the Rose port

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Live site: <https://producdevity.github.io/MiyooMini-Ports/>
 | [Captain Claw](https://github.com/ArticlessCZ-Coder/captain-claw-miyoo/releases) | Platform | Playable | Owned data | ArticlessCZ-Coder |
 | [SuperTux](https://github.com/andrigamerita/supertux/releases) | Platform | Playable | Free | andrigamerita |
 | [Frozen Bubble](https://github.com/mehdisadeghi/frozen-bubble-onion/releases) | Puzzle, Arcade | Playable | Free | mehdisadeghi |
+| [Petals Around the Rose](https://github.com/schizophreek/petals/releases) | Puzzle | Playable | Free | schizophreek |
 | [Elasto Mania](https://github.com/neri-rnd/elma-miyoo/releases) | Racing, Platform | Playable | Owned data | neri-rnd |
 | [Super Haxagon](https://github.com/RedTopper/Super-Haxagon/releases) | Reflex | Playable | Free | RedTopper |
 | [Stardew Valley](https://github.com/Producdevity/stardew-valley-miyoo-mini-port/releases) | RPG, Simulation | Experimental | Owned data | Producdevity | EmuReady |

--- a/porters.json
+++ b/porters.json
@@ -117,6 +117,9 @@
     },
     "zoitrok": {
       "github": "https://github.com/zoitrok"
-    }
+    },
+    "schizophreek": {
+    "github": "https://github.com/schizophreek"
+}
   }
 }

--- a/porters.json
+++ b/porters.json
@@ -117,9 +117,9 @@
     },
     "zoitrok": {
       "github": "https://github.com/zoitrok"
-    },
+},
     "schizophreek": {
-    "github": "https://github.com/schizophreek"
-}
+      "github": "https://github.com/schizophreek"
+    }
   }
 }

--- a/porters.json
+++ b/porters.json
@@ -117,7 +117,7 @@
     },
     "zoitrok": {
       "github": "https://github.com/zoitrok"
-},
+    },
     "schizophreek": {
       "github": "https://github.com/schizophreek"
     }

--- a/ports.json
+++ b/ports.json
@@ -407,7 +407,7 @@
       "status": "playable",
       "assets": "free",
       "upstream": "https://github.com/schizophreek/petals/releases",
-      "image": "https://raw.githubusercontent.com/schizophreek/petals/main/petals_scr.png",
+      "image": "https://github.com/schizophreek/petals/blob/482b7f46197650b78fc58acad0be5755e833b93e/petals_scr.png",
       "notes": "Standalone dice logic puzzle port for Miyoo Mini and Miyoo A30.",
       "porter": ["schizophreek"]
     }

--- a/ports.json
+++ b/ports.json
@@ -406,7 +406,7 @@
       "categories": ["puzzle"],
       "status": "playable",
       "assets": "free",
-      "upstream": "https://github.com/schizophreek/petals",
+      "upstream": "https://github.com/schizophreek/petals/releases",
       "image": "https://raw.githubusercontent.com/schizophreek/petals/main/petals_scr.png",
       "notes": "Standalone dice logic puzzle port for Miyoo Mini and Miyoo A30.",
       "porter": ["schizophreek"]

--- a/ports.json
+++ b/ports.json
@@ -400,6 +400,16 @@
       "image": "https://raw.githubusercontent.com/k2-ant/mini-tracker/HEAD/branding/icon-hires.png",
       "notes": "Backlog and play-time tracker that runs on the handheld; reads Onion's play activity read-only, box-art grid. All devices.",
       "porter": ["k2-ant"]
+    },
+    {
+      "name": "Petals Around the Rose",
+      "category": "puzzle",
+      "status": "playable",
+      "assets": "free",
+      "upstream": "https://github.com/schizophreek/petals",
+      "image": "https://raw.githubusercontent.com/schizophreek/petals/main/petals_scr.png",
+      "notes": "Standalone dice logic puzzle port for Miyoo Mini and Miyoo A30.",
+      "porter": ["schizophreek"]
     }
   ]
 }

--- a/ports.json
+++ b/ports.json
@@ -407,7 +407,7 @@
       "status": "playable",
       "assets": "free",
       "upstream": "https://github.com/schizophreek/petals/releases",
-      "image": "https://github.com/schizophreek/petals/blob/482b7f46197650b78fc58acad0be5755e833b93e/petals_scr.png",
+      "image": "https://raw.githubusercontent.com/schizophreek/petals/482b7f46197650b78fc58acad0be5755e833b93e/petals_scr.png",
       "notes": "Standalone dice logic puzzle port for Miyoo Mini and Miyoo A30.",
       "porter": ["schizophreek"]
     }

--- a/ports.json
+++ b/ports.json
@@ -403,7 +403,7 @@
     },
     {
       "name": "Petals Around the Rose",
-      "category": "puzzle",
+      "categories": ["puzzle"],
       "status": "playable",
       "assets": "free",
       "upstream": "https://github.com/schizophreek/petals",


### PR DESCRIPTION
Submitted Petals Around the Rose

## Port

- Name: Petals Around the Rose
- Upstream: https://github.com/schizophreek/petals/releases
- Porter(s): schizophreek
- Tested on: Miyoo Mini (Onion OS), Miyoo Mini Plus (Onion OS), Miyoo A30 (Spruce OS)

## Checklist

- [x] The port does not distribute any copyrighted or proprietary material.
- [x] Added/updated in `ports.json`
- [x] Porter(s) have a profile in `porters.json`
- [x] `upstream` points to `/releases` (or the repo root if there are none)
- [x] Not already in [OnionUI/Ports-Collection](https://github.com/OnionUI/Ports-Collection) or Onion's Package Manager
- [ ] If edited outside the pre-commit hook: ran `pnpm gen:readme`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds “Petals Around the Rose” to `ports.json`, registers porter `schizophreek` in `porters.json`, and regenerates `README.md` to list the new port. This exposes a playable, free puzzle with a releases-based upstream and a pinned preview image.

- Verify the `ports.json` entry: `upstream` points to `/releases`, `categories` is `["puzzle"]`, `status` is `playable`, `assets` is `free`, and `porter` is `["schizophreek"]`.
- Confirm the image renders: https://raw.githubusercontent.com/schizophreek/petals/482b7f46197650b78fc58acad0be5755e833b93e/petals_scr.png.
- Check device notes match support: “Miyoo Mini and Miyoo A30”; decide whether to add Miyoo Mini Plus based on tests.
- Confirm `README.md` lists the port with category “Puzzle,” status “Playable,” assets “Free,” and porter “schizophreek.”

<sup>Written for commit 39a756c1d904bc61e13dd6fda21ed60558ac8d32. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Producdevity/MiyooMini-Ports/pull/2?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the “Petals Around the Rose” puzzle port, including its description, category, free-play availability, artwork, device notes, source repository, release link, and contributor information.
  * Added a new porter profile with a link to their GitHub page.
  * Updated the ports listing to make the new puzzle available and discoverable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->