### PR TITLE
add Mines of Moria por

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Live site: <https://producdevity.github.io/MiyooMini-Ports/>
 | [Petals Around the Rose](https://github.com/schizophreek/petals/releases) | Puzzle | Playable | Free | schizophreek |
 | [Elasto Mania](https://github.com/neri-rnd/elma-miyoo/releases) | Racing, Platform | Playable | Owned data | neri-rnd |
 | [Super Haxagon](https://github.com/RedTopper/Super-Haxagon/releases) | Reflex | Playable | Free | RedTopper |
+| [Mines of Moria](https://github.com/mxmgorin/moria-handheld/releases) | RPG | Playable | Free | mxmgorin |
 | [Stardew Valley](https://github.com/Producdevity/stardew-valley-miyoo-mini-port/releases) | RPG, Simulation | Experimental | Owned data | Producdevity | EmuReady |
 | [Undertale](https://github.com/cobaltgit/Butterscotch/releases) | RPG | Playable | Owned data | cobaltgit |
 | [POSTAL](https://github.com/bostrt/POSTAL-miyoo/releases) | Shooter | Experimental | Owned data | bostrt |

--- a/ports.json
+++ b/ports.json
@@ -420,6 +420,16 @@
       "image": "https://raw.githubusercontent.com/ArticlessCZ-Coder/jazz2-miyoo/3de963ee96dc8db505a6eae4f504659dbb24b16e/docs/screenshot.png",
       "notes": "Jazz² Resurrection engine port. Supply your own copy of the game; a Windows converter is included in the download. Steady 30 FPS, sound, music and cinematics; single-player only, and the textured backgrounds are drawn flat because the effect cost a third of the frame.",
       "porter": ["ArticlessCZ-Coder"]
+    },
+    {
+      "name": "Mines of Moria",
+      "categories": ["rpg"],
+      "status": "playable",
+      "assets": "free",
+      "upstream": "https://github.com/mxmgorin/moria-handheld/releases",
+      "image": "https://raw.githubusercontent.com/mxmgorin/moria-handheld/a55fabc634c8c919f20a5b3319b12bd5a1db79b5/portmaster/screenshot.png",
+      "notes": "Descend the Mines of Moria, level by level, and slay the Balrog waiting at the bottom. Rufe.org's rebuild of Umoria, itself the 1983 roguelike by Robert Alan Koeneke that Angband and much of the genre grew out of: permadeath, a randomly generated dungeon on every stairway, a town to spend your gold in between dives. This build uses the graphical client, with sprite tiles and a map that fills the screen. Press Start for the in-game menu, where the tile renderer, magnification and colours can all be changed.",
+      "porter": ["mxmgorin"]
     }
   ]
 }


### PR DESCRIPTION
## Port

- Name: Mines of Moria
- Upstream: https://github.com/mxmgorin/moria-handheld
- Porter(s): mxmgorin
- Tested on: Miyoo Mini v2

## Checklist

- [x] The port does not distribute any copyrighted or proprietary material.
- [x] Added/updated in `ports.json`
- [x] Porter(s) have a profile in `porters.json`
- [x] `upstream` points to `/releases` (or the repo root if there are none)
- [x] Not already in [OnionUI/Ports-Collection](https://github.com/OnionUI/Ports-Collection) or Onion's Package Manager
- [] If edited outside the pre-commit hook: ran `pnpm gen:readme`



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the Mines of Moria port to the catalog and site so users can install a free, playable roguelike. Previously absent; now listed with upstream releases, a screenshot, and play notes.

- Adds a `ports.json` entry with: name, categories ["rpg"], status "playable", assets "free", upstream releases URL, pinned screenshot URL, detailed notes, and porter ["mxmgorin"].
- Adds a `README.md` table row linking to the upstream releases.
- Verify the upstream and screenshot URLs resolve. No changes to existing ports and no migration required.

<sup>Written for commit 464d965cb96b6bb4025443e8e263baf5d017f9a5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Producdevity/MiyooMini-Ports/pull/3?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
- Added **Mines of Moria**, a free, playable RPG port.
- Includes gameplay and configuration details, upstream and screenshot links, and porter attribution.

## Documentation
- Added Mines of Moria to the available ports table.
- Listed its RPG classification, free assets, playability status, project information, and related resources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->