### PR TITLE
Add Jazz Jackrabbit 2 (Jazz² Resurrection) port

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Live site: <https://producdevity.github.io/MiyooMini-Ports/>
 | [Half-Life](https://github.com/IC-0n417/half-life-miyoo-mini-plus/releases) | FPS | Prerelease | Owned data | IC-0n417 |
 | [Quake II](https://github.com/Apaczer/quake2-miyoo/releases) | FPS | Playable | Owned data | Apaczer |
 | [Captain Claw](https://github.com/ArticlessCZ-Coder/captain-claw-miyoo/releases) | Platform | Playable | Owned data | ArticlessCZ-Coder |
+| [Jazz Jackrabbit 2](https://github.com/ArticlessCZ-Coder/jazz2-miyoo/releases) | Platform | Playable | Owned data | ArticlessCZ-Coder |
 | [SuperTux](https://github.com/andrigamerita/supertux/releases) | Platform | Playable | Free | andrigamerita |
 | [Frozen Bubble](https://github.com/mehdisadeghi/frozen-bubble-onion/releases) | Puzzle, Arcade | Playable | Free | mehdisadeghi |
 | [Petals Around the Rose](https://github.com/schizophreek/petals/releases) | Puzzle | Playable | Free | schizophreek |

--- a/ports.json
+++ b/ports.json
@@ -410,6 +410,16 @@
       "image": "https://raw.githubusercontent.com/schizophreek/petals/482b7f46197650b78fc58acad0be5755e833b93e/petals_scr.png",
       "notes": "Standalone dice logic puzzle port for Miyoo Mini and Miyoo A30.",
       "porter": ["schizophreek"]
+    },
+    {
+      "name": "Jazz Jackrabbit 2",
+      "categories": ["platform"],
+      "status": "playable",
+      "assets": "owned",
+      "upstream": "https://github.com/ArticlessCZ-Coder/jazz2-miyoo/releases",
+      "image": "https://raw.githubusercontent.com/ArticlessCZ-Coder/jazz2-miyoo/3de963ee96dc8db505a6eae4f504659dbb24b16e/docs/screenshot.png",
+      "notes": "Jazz² Resurrection engine port. Supply your own copy of the game; a Windows converter is included in the download. Steady 30 FPS, sound, music and cinematics; single-player only, and the textured backgrounds are drawn flat because the effect cost a third of the frame.",
+      "porter": ["ArticlessCZ-Coder"]
     }
   ]
 }


### PR DESCRIPTION
Adds the Miyoo Mini port of [Jazz² Resurrection](https://github.com/deathkiller/jazz2-native), the open-source Jazz Jackrabbit 2 engine.

- **Release:** https://github.com/ArticlessCZ-Coder/jazz2-miyoo/releases
- **Status:** playable — a steady 30 FPS on Miyoo Mini and Mini Plus, with sound effects, module music and the intro/ending cinematics
- **Assets:** owned. No game data is distributed; the download includes a Windows converter that turns the player's own installation into the format the port loads

Known limitations, all in the entry's notes: single-player only, and the textured backgrounds are drawn flat because JJ2's warped perspective sky is a per-pixel effect that cost about a third of the frame on this hardware.

The screenshot is captured from the device's own framebuffer, so it is what the panel actually shows.

Same porter as the Captain Claw entry; `porters.json` already has the handle, so only `ports.json` changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Jazz Jackrabbit 2 (Jazz² Resurrection) to `ports.json` and the `README.md` catalog, exposing the open‑source JJ2 engine port for Miyoo Mini/Mini Plus. The port runs at a steady 30 FPS with sound, music, and cinematics; it is single‑player only and renders textured backgrounds flat; users must supply game assets via the included Windows converter.

- Validate the `upstream` release URL and `image` link resolve.
- Notes cover limitations and the owned‑assets converter; no game data is distributed.
- `porters.json` stays unchanged; `ArticlessCZ-Coder` is already listed.

<sup>Written for commit 956986301d0c16caa687285644416c4d7673ac4a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Producdevity/MiyooMini-Ports/pull/4?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the playable “Jazz Jackrabbit 2” port to the owned-assets collection.
  * Included release information, a screenshot, gameplay notes, and attribution details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->