### PR TITLE
Add Minecraft: Bedrock Edition 1.2 for the Miyoo Mini Plus

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Live site: <https://producdevity.github.io/MiyooMini-Ports/>
 | [Stardew Valley](https://github.com/Producdevity/stardew-valley-miyoo-mini-port/releases) | RPG, Simulation | Experimental | Owned data | Producdevity | EmuReady |
 | [Undertale](https://github.com/cobaltgit/Butterscotch/releases) | RPG | Playable | Owned data | cobaltgit |
 | [POSTAL](https://github.com/bostrt/POSTAL-miyoo/releases) | Shooter | Experimental | Owned data | bostrt |
+| [Minecraft: Bedrock Edition 1.2](https://github.com/DankMiimer/minecraft-bedrock-miyoo-mini-plus/releases) | Simulation | Experimental | Owned data | DankMiimer |
 | [OpenRCT2](https://github.com/scheeseman486/OpenRCT2mini/releases) | Simulation | Playable | Owned data | scheeseman486 |
 
 <!-- END PORTS -->

--- a/porters.json
+++ b/porters.json
@@ -120,6 +120,10 @@
     },
     "schizophreek": {
       "github": "https://github.com/schizophreek"
+    },
+    "DankMiimer": {
+      "github": "https://github.com/DankMiimer",
+      "image": "https://avatars.githubusercontent.com/u/185956673?v=4"
     }
   }
 }

--- a/ports.json
+++ b/ports.json
@@ -410,6 +410,16 @@
       "image": "https://raw.githubusercontent.com/schizophreek/petals/482b7f46197650b78fc58acad0be5755e833b93e/petals_scr.png",
       "notes": "Standalone dice logic puzzle port for Miyoo Mini and Miyoo A30.",
       "porter": ["schizophreek"]
+    },
+    {
+      "name": "Minecraft: Bedrock Edition 1.2",
+      "categories": ["simulation"],
+      "status": "experimental",
+      "assets": "owned",
+      "upstream": "https://github.com/DankMiimer/minecraft-bedrock-miyoo-mini-plus/releases",
+      "image": "https://raw.githubusercontent.com/DankMiimer/minecraft-bedrock-miyoo-mini-plus/HEAD/docs/miyoo-mini-plus-bedrock.jpg",
+      "notes": "Bedrock 1.2.20.2 through the minecraft-linux launcher on a software GL stack. Mini Plus only. No GPU, so 6-8 fps: choose 160x120 at the launch prompt, and relaunch at 320x240 if you need the Settings or Store buttons. Supply your own Android APK.",
+      "porter": ["DankMiimer"]
     }
   ]
 }


### PR DESCRIPTION
## Port

- Name: Minecraft: Bedrock Edition 1.2
- Upstream: https://github.com/DankMiimer/minecraft-bedrock-miyoo-mini-plus/releases
- Porter(s): DankMiimer
- Tested on: Miyoo Mini Plus (OnionOS). Mini and Mini Flip untested.

Bedrock 1.2.20.2 running through the [minecraft-linux](https://github.com/minecraft-linux)
launcher on a software GL stack, so it works on the Mini Plus despite there
being no GPU. No game files are distributed — the user supplies their own
official Android APK.

Marked `experimental` rather than `playable`: it measures 6-8 fps standing
still and about 5 fps while moving, which is the low-FPS case that status
describes. The upstream README documents the measurements and the recommended
160x120 internal resolution.

`simulation` is the closest fit in the category enum; there is no
sandbox/survival value.

Also adds the `DankMiimer` profile to `porters.json`, since CI requires one for
any handle referenced in `ports.json`.

## Checklist

- [x] The port does not distribute any copyrighted or proprietary material.
- [x] Added/updated in `ports.json`
- [x] Porter(s) have a profile in `porters.json`
- [x] `upstream` points to `/releases` (or the repo root if there are none)
- [x] Not already in [OnionUI/Ports-Collection](https://github.com/OnionUI/Ports-Collection) or Onion's Package Manager
- [x] If edited outside the pre-commit hook: ran `pnpm gen:readme`

`tsx scripts/validate-ports.ts` reports `42 entries OK, 37 porters OK`, and
`biome check` is clean on the changed files.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Minecraft: Bedrock Edition 1.2 as an experimental Mini Plus–only port via the `minecraft-linux` software-GL launcher. Also adds the `DankMiimer` porter profile so CI and the site can list the port.

- Review
  - Verify `ports.json` entry: category `simulation`, status `experimental`, assets `owned`, upstream points to `/releases`, image URL valid, Mini Plus–only note, 6–8 fps performance with 160x120 recommendation, and mention of `minecraft-linux`.
  - Confirm `README.md` includes the new row and `porters.json` adds `DankMiimer` (GitHub + avatar).
  - No code changes—only data and docs updates.

- Rollout
  - No migration. Users must provide the official Android APK; no game files are distributed.

<sup>Written for commit a6917dd8168c518c318f03f457eadb724456460f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Producdevity/MiyooMini-Ports/pull/5?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Minecraft: Bedrock Edition 1.2 as an experimental simulation port.
  - Included availability details, required owned game data, release information, usage notes, imagery, and contributor attribution.

- **Documentation**
  - Updated the catalog with the new port and its contributor profile.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->