### PR TITLE
add Monk Tower port

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Live site: <https://producdevity.github.io/MiyooMini-Ports/>
 | [Elasto Mania](https://github.com/neri-rnd/elma-miyoo/releases) | Racing, Platform | Playable | Owned data | neri-rnd |
 | [Super Haxagon](https://github.com/RedTopper/Super-Haxagon/releases) | Reflex | Playable | Free | RedTopper |
 | [Mines of Moria](https://github.com/mxmgorin/moria-handheld/releases) | RPG | Playable | Free | mxmgorin |
+| [Monk Tower](https://github.com/mxmgorin/monktower-handheld/releases) | RPG | Playable | Free | mxmgorin |
 | [Stardew Valley](https://github.com/Producdevity/stardew-valley-miyoo-mini-port/releases) | RPG, Simulation | Experimental | Owned data | Producdevity | EmuReady |
 | [Undertale](https://github.com/cobaltgit/Butterscotch/releases) | RPG | Playable | Owned data | cobaltgit |
 | [POSTAL](https://github.com/bostrt/POSTAL-miyoo/releases) | Shooter | Experimental | Owned data | bostrt |

--- a/ports.json
+++ b/ports.json
@@ -440,6 +440,16 @@
       "image": "https://raw.githubusercontent.com/mxmgorin/moria-handheld/a55fabc634c8c919f20a5b3319b12bd5a1db79b5/portmaster/screenshot.png",
       "notes": "Descend the Mines of Moria, level by level, and slay the Balrog waiting at the bottom. Rufe.org's rebuild of Umoria, itself the 1983 roguelike by Robert Alan Koeneke that Angband and much of the genre grew out of: permadeath, a randomly generated dungeon on every stairway, a town to spend your gold in between dives. This build uses the graphical client, with sprite tiles and a map that fills the screen. Press Start for the in-game menu, where the tile renderer, magnification and colours can all be changed.",
       "porter": ["mxmgorin"]
+    },
+    {
+      "name": "Monk Tower",
+      "categories": ["rpg"],
+      "status": "playable",
+      "assets": "free",
+      "upstream": "https://github.com/mxmgorin/monktower-handheld/releases",
+      "image": "https://raw.githubusercontent.com/mxmgorin/monktower-handheld/fe5f4a27f741c0d16eb04cd9688ce3e274f05b60/monk-tower-cover.png",
+      "notes": "A simple coffee-break roguelike game. Roam through 20 levels of the cloister tower, to retrieve the lost manuscript. Carefully manage your weapons, as they get damaged quicker than you think. Separate packages for OnionOS, spruceOS and Allium.",
+      "porter": ["mxmgorin"]
     }
   ]
 }


### PR DESCRIPTION
## Port

- Name:  Monk Tower
- Upstream: https://github.com/mxmgorin/monktower-handheld
- Porter(s): mxmgorin
- Tested on: Miyoo Mini v2, Miyoo Mini Flip

## Checklist

- [x] The port does not distribute any copyrighted or proprietary material.
- [x] Added/updated in `ports.json`
- [x] Porter(s) have a profile in `porters.json`
- [x] `upstream` points to `/releases` (or the repo root if there are none)
- [x] Not already in [OnionUI/Ports-Collection](https://github.com/OnionUI/Ports-Collection) or Onion's Package Manager
- [ ] If edited outside the pre-commit hook: ran `pnpm gen:readme`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the playable “Monk Tower” RPG port to the available ports catalog.
  * Included its release information, cover image, gameplay description, supported package variants, and free-asset status.
  * Updated the ports table with attribution details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->