### PR TITLE
add Retsurf port

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Live site: <https://producdevity.github.io/MiyooMini-Ports/>
 | [PocketFlex](https://github.com/jackharvest/PocketFlex/releases) | App | Experimental | Free | jackharvest |
 | [PocketStream](https://github.com/IC-0n417/PocketStream/releases) | App | Experimental | Free | IC-0n417 |
 | [retsend](https://github.com/mxmgorin/retsend/releases) | App | Playable | Free | mxmgorin |
+| [retsurf](https://github.com/mxmgorin/retsurf/releases) | App | Experimental | Free | mxmgorin |
 | [Speed Test](https://github.com/josegonzalez/miyoo-speedtest/releases) | App | Playable | Free | josegonzalez |
 | [storii](https://github.com/pcorbel/storii/releases) | App | Playable | Free | pcorbel |
 | [Syncthing](https://github.com/XK9274/syncthing-app-miyoo) | App | Playable | Free | XK9274 |

--- a/ports.json
+++ b/ports.json
@@ -490,6 +490,16 @@
       "image": "https://github.com/XK9274/better-wifi-miyoo/assets/47260768/78de2a92-c2d6-405f-8fe3-906b11ad2c16",
       "notes": "Rebuilt WiFi manager with a simple GUI: scan, connect, and manage networks from the device. Mini Plus (WiFi).",
       "porter": ["XK9274"]
+    },
+    {
+      "name": "retsurf",
+      "categories": ["app"],
+      "status": "experimental",
+      "assets": "free",
+      "upstream": "https://github.com/mxmgorin/retsurf/releases",
+      "image": "https://raw.githubusercontent.com/mxmgorin/retsurf/2793750ca6db62d0eb6098e01dcacec9d8084767/resources/images/retsurf-hints.png",
+      "notes": "A web browser built on the Servo engine, designed for gamepad navigation. Features include Vimium-style link hints, an on-screen keyboard, tabs, bookmarks, reader mode, and downloads.",
+      "porter": ["mxmgorin"]
     }
   ]
 }


### PR DESCRIPTION
## Port

- Name: retsurf
- Upstream: https://github.com/mxmgorin/retsurf
- Porter(s): mxmgorin
- Tested on: Miyoo Mini Flip

## Checklist

- [x] The port does not distribute any copyrighted or proprietary material.
- [x] Added/updated in `ports.json`
- [x] Porter(s) have a profile in `porters.json`
- [x] `upstream` points to `/releases` (or the repo root if there are none)
- [x] Not already in [OnionUI/Ports-Collection](https://github.com/OnionUI/Ports-Collection) or Onion's Package Manager
- [ ] If edited outside the pre-commit hook: ran `pnpm gen:readme`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the experimental `Retsurf` port, a Servo-based web browser with gamepad navigation, link hints, an on-screen keyboard, tabs, bookmarks, reader mode, and downloads.

<sup>Written for commit b5702deb05894e37aa8c7b5d685668f585d93213. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Producdevity/MiyooMini-Ports/pull/9?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the experimental Retsurf web browser port to the available ports catalog.
  - Included release information, preview imagery, and details about gamepad navigation, link hints, on-screen keyboard, tabs, bookmarks, reader mode, and downloads.
  - Added Retsurf to the ports reference table and identified its assets as free.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->